### PR TITLE
Always throw error if config file is specified

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -264,7 +264,7 @@ const loadConfig = async (cwd, entry, args) => {
 		try {
 			content = await readFile(location, 'utf8');
 		} catch (err) {
-			if (err.code === 'ENOENT') {
+			if (err.code === 'ENOENT' && file !== args['--config']) {
 				continue;
 			}
 


### PR DESCRIPTION
As mentioned in #498 current behaviour is to silently fail if `--config` file is not found. This can result in running the server with an unintended configuration without the user knowing about it.

The change in this PR ensures that errors are thrown if the `--config` file is explicitly specified.


Example behaviour:
```
$ serve -c nonexistent.json
ERROR: Not able to read /foo/nonexistent.json: ENOENT: no such file or directory, open '/foo/nonexistent.json'
```