### PR TITLE
Add ssi #include support

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -363,6 +363,7 @@ const loadConfig = async (cwd, entry, args) => {
 			'--config': String,
 			'--no-clipboard': Boolean,
 			'--no-compression': Boolean,
+			'--symlinks': Boolean,
 			'--ssi': String,
 			'-h': '--help',
 			'-v': '--version',

--- a/bin/serve.js
+++ b/bin/serve.js
@@ -202,7 +202,7 @@ const startEndpoint = (endpoint, config, args, previous) => {
 					// SSI part
 					if ((fileExt === 'html' || fileExt === 'shtml' || fileExt === 'htm') && config.ssi) {
 						stream.on('data', (chunk) => {
-							const ssi = new SSI({ location: config.ssi });
+							const ssi = new SSI({ location: config.ssi, localPath: path.resolve(), defaultCharset: 'utf-8' });
 							const newHtml = ssi(chunk.toString());
 							const newStream = new Readable();
 							newStream._read = () => {};

--- a/bin/ssi.js
+++ b/bin/ssi.js
@@ -5,7 +5,12 @@ const SSI = function (param) {
 	options.includesMatcher = /<!--\s?#\s?include\s+(?:virtual|file)="([^"]+)"(?:\s+stub="(\w+)")?\s+-->/;
 
 	function getContent(location) {
-		const url = `${options.location}${location}`;
+		let url;
+		if (location.substring(0, 4) === 'http') {
+			url = location;
+		} else {
+			url = `${options.location}${location}`;
+		}
 		const res = request('GET', url);
 		return [res.statusCode, res.statusCode < 400 ? res.getBody('utf8') : ''];
 	}

--- a/bin/ssi.js
+++ b/bin/ssi.js
@@ -1,0 +1,42 @@
+const request = require('sync-request');
+
+const SSI = function (param) {
+	const options = param;
+	options.includesMatcher = /<!--\s?#\s?include\s+(?:virtual|file)="([^"]+)"(?:\s+stub="(\w+)")?\s+-->/;
+
+	function getContent(location) {
+		const url = `${options.location}${location}`;
+		const res = request('GET', url);
+		return [res.statusCode, res.statusCode < 400 ? res.getBody('utf8') : ''];
+	}
+
+	function processInclude(part, blocks) {
+		const matches = part.match(options.includesMatcher);
+		if (!matches) {
+			return part;
+		}
+
+		const location = matches[1];
+		const stub = matches[2];
+
+		const [status, body] = getContent(location);
+		return status === 200 ? body : blocks[stub];
+	}
+
+	function compile(content) {
+		let output = [];
+		const blocks = {};
+		const splitContent = content.split('\n');
+
+		for (const line of splitContent) {
+			const part = line.trim();
+			output += processInclude(part, blocks);
+		}
+
+		return output;
+	}
+
+	return (content) => compile(content);
+};
+
+module.exports = SSI;

--- a/bin/ssi.js
+++ b/bin/ssi.js
@@ -6,13 +6,15 @@ const SSI = function (param) {
 
 	function getContent(location) {
 		let url;
-		if (location.substring(0, 4) === 'http') {
+		const urlPattern = /(http|ftp|https):\/\/[\w-]+(\.[\w-]+)*([\w.,@?^=%&amp;:\/~+#-]*[\w@?^=%&amp;\/~+#-])?/;
+		const matches = location.match(urlPattern);
+		if (matches) {
 			url = location;
 		} else {
 			url = `${options.location}${location}`;
 		}
 		const res = request('GET', url);
-		return [res.statusCode, res.statusCode < 400 ? res.getBody('utf8') : ''];
+		return [res.statusCode, res.statusCode < 400 ? res.getBody('utf8') : [200, `ERROR : ${location}`]];
 	}
 
 	function processInclude(part, blocks) {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "compression": "1.7.3",
     "serve-handler": "6.0.2",
     "sync-request": "6.1.0",
-    "update-check": "1.5.2"
+    "update-check": "1.5.2",
+    "iconv-lite": "0.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "chalk": "2.4.1",
     "clipboardy": "1.2.3",
     "compression": "1.7.3",
+    "chardet": "0.8.0",
     "serve-handler": "6.0.2",
     "sync-request": "6.1.0",
     "update-check": "1.5.2",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "clipboardy": "1.2.3",
     "compression": "1.7.3",
     "serve-handler": "6.0.2",
+    "sync-request": "6.1.0",
     "update-check": "1.5.2"
   }
 }


### PR DESCRIPTION
SSI is an old techno but,
adding SSI include support to this package would be really helpful for the devs that still (have to) use it.

I added the _--ssi_ : String key,
if found, and in is correct URL format :

- the serve-handler function param "_createReadStream_" is extended
- the html file is read(_readFileSync_) and transformed into a string,
- the SSI function is trigger with the --ssi URL and the file as a string as parameter
- the SSI function look for < !--#include virtual="/path/to/the/index.html" -- > patterns
- if match is found, dl the file **synchronously**  with the package _sync-request_ and the _--ssi_ URL as base and replace the match with the dl file content
- finally return the formatted html, this html is pushed in a _new Readable()_ and return in _createReadStream_

Note: the **synchronously** in point 5 will cause time out if the file does not exist on the server...
this could be improve / prevent