### PR TITLE
add charset detection and override option for html / htm / css / ...

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -169,70 +169,99 @@ const getNetworkAddress = () => {
 	}
 };
 
-const scanContentTypeCharset = (fullPath, ext) => {
+const scanContentTypeCharset = (content, ext) => {
 	const defaultCharset = 'utf-8';
-
-	let content = '';
 	let charset = [];
 	let matcher = null;
-	try {
-		content = fs.readFileSync(fullPath, 'utf8');
-	} catch (e) {
-		console.error(`could not find the file ${fullPath}`);
-	}
 
-	if (ext === 'html') {
+	if (ext === 'html' || ext === 'htm') {
 		matcher = /<meta(?!\s*(?:name|value)\s*=)[^>]*?charset\s*=[\s"']*([^\s"'/>]*)/;
 	} else if (ext === 'css') {
 		matcher = /@charset\s*[\s"']*([^\s"'/>]*)/;
 	}
-
 	charset = content.match(matcher);
 	charset = charset && charset.length > 1 ? charset[1].toLowerCase() : defaultCharset;
 
-	return `text/${ext}; charset=${charset}`;
+	return charset;
+};
+
+const extractCharset = (extention, fileContent, forcedCharset) => {
+	if (forcedCharset) {
+		return forcedCharset;
+	}
+
+	return scanContentTypeCharset(fileContent, extention);
+};
+
+const realPath = (relativePath) => {
+	const possiblePaths = [
+		path.join(relativePath, 'index.html'),
+		relativePath.endsWith('/') ? relativePath.replace(/\/$/g, '.html') : `${relativePath}.html`
+	].filter((item) => path.basename(item) !== '.html');
+
+	for (let index = 0; index < possiblePaths.length; index++) {
+		const related = possiblePaths[index];
+		const absolutePath = path.join(process.cwd(), related);
+		let exist = false;
+		try {
+			exist = fs.existsSync(absolutePath);
+		} catch (err) {
+			continue;
+		}
+
+		if (exist) {
+			return absolutePath;
+		}
+	}
+
+	return null;
 };
 
 const startEndpoint = (endpoint, config, args, previous) => {
 	const {isTTY} = process.stdout;
 	const clipboard = args['--no-clipboard'] !== true;
 	const compress = args['--no-compression'] !== true;
+	const allowExt = [
+		'css',
+		'html',
+		'htm',
+		'shtml'
+	];
 
 	const server = http.createServer(async (request, response) => {
 		if (compress) {
 			await compressionHandler(request, response);
 		}
 
-
-		const fullPath = path.resolve() + request.url + (request.url === '/' ? 'index.html' : '');
-		const extention = fullPath.split(/\#|\?/)[0].split('.').pop()
-			.trim()
-			.toLowerCase();
-
-		// if the file type is html or css we can try to detect the charset specified in the content
-		if (extention === 'css' || extention === 'html' || extention === 'htm') {
-			if (!config.headers) {
-				config.headers = [];
-			}
-
-			if (config.charset) {
-				config.headers.push({
-					source: (request.url === '/' ? 'index.html' : ''),
-					headers: [{
-						key: 'Content-Type',
-						value: `text/${extention}; charset=${config.charset}`
-					}]
-				});
-			} else {
-				config.headers.push({
-					source: (request.url === '/' ? 'index.html' : ''),
-					headers: [{
-						key: 'Content-Type',
-						value: scanContentTypeCharset(fullPath, extention)
-					}]
-				});
-			}
+		let fullPath = path.resolve() + request.url;
+		let relativePath = request.url;
+		if (path.extname(fullPath) === '') {
+			fullPath = realPath(request.url) ? realPath(request.url) : fullPath;
+			relativePath = path.relative(process.cwd(), fullPath);
 		}
+
+		const extention = fullPath.split(/\#|\?/)[0].split('.').pop();
+
+		let charset = 'utf-8';
+		if (allowExt.indexOf(extention) >= 0) {
+			try {
+				const fileContent = fs.readFileSync(fullPath, 'utf-8');
+				charset = extractCharset(extention, fileContent, config.charset);
+				if (!config.headers) {
+					config.headers = [];
+				}
+
+				config.headers.push({
+					source: relativePath,
+					headers: [{
+						key: 'Content-Type',
+						value: `text/${extention}; charset=${config.charset ? config.charset : charset}`
+					}]
+				});
+			} catch (err) {
+				console.log('');
+			}
+		} // if (allowExt.indexOf(extention) >= 0)
 
 		return handler(request, response, config);
 	});

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "chalk": "2.4.1",
     "clipboardy": "1.2.3",
     "compression": "1.7.3",
+    "chardet": "0.8.0",
     "serve-handler": "6.0.2",
     "update-check": "1.5.2"
   }


### PR DESCRIPTION
- add **--charset** option:String in config
- in _startEndpoint_ before _handler_ function check file extension
- if html | htm | css,
- if **config.charset** is set, force every request header  **Content-type** to **config.charset** content
- else load the requested file in _scanContentTypeCharset_ and scroll its content to find **<meta ... charset="...** or **@charset "...**
- if found, set the header **Content-Type**
- if not set utf-8 default header

the rest is handle bye _serve-handeler_

Can / should be extended to other extention (json, xml, etc... ?)