### PR TITLE
Fix undefined local network address

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -225,7 +225,7 @@ const startEndpoint = (endpoint, config, args, previous) => {
 			const ip = getNetworkAddress();
 
 			localAddress = `${httpMode}://${address}:${details.port}`;
-			networkAddress = `${httpMode}://${ip}:${details.port}`;
+			networkAddress = networkAddress ? `${httpMode}://${ip}:${details.port}` : null;
 		}
 
 		if (isTTY && process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
In the event that serve is started when the host machine is not connected to the internet, the local network address will show up as undefined. Adding a simple check fixes this. When this is the case, the local network address won't appear anymore.

- Fix undefined local network address