### PR TITLE
Document CORS option

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -83,6 +83,8 @@ const getHelp = () => chalk`
 
       -c, --config                        Specify custom path to \`serve.json\`
 
+      -C, --cors						  Enable CORS, sets \`Access-Control-Allow-Origin\` to \`*\`
+
       -n, --no-clipboard                  Do not copy the local address to the clipboard
 
       -u, --no-compression                Do not compress files


### PR DESCRIPTION
The option to enable CORS has returned, but the documentation did not. The spacing may be off since I did this directly in GitHub.