### PR TITLE
add undocumented option flag to the help command output

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -77,6 +77,8 @@ const getHelp = () => chalk`
       -l, --listen {underline listen_uri}             Specify a URI endpoint on which to listen (see below) -
                                           more than one may be specified to listen in multiple places
 
+      -p                                  Specify custom port
+
       -d, --debug                         Show debugging information
 
       -s, --single                        Rewrite all not-found requests to \`index.html\`


### PR DESCRIPTION
The -p port command is not available in the help command. I assumed it wasn't available as a result of this. I think documenting tihs in the help command output is a good idea.