### PR TITLE
Add Access-Control-Allow-Headers=range header when in CORS

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -188,6 +188,7 @@ const startEndpoint = (endpoint, config, args, previous) => {
 	const serverHandler = async (request, response) => {
 		if (args['--cors']) {
 			response.setHeader('Access-Control-Allow-Origin', '*');
+			response.setHeader('Access-Control-Allow-Headers', 'range');
 		}
 		if (compress) {
 			await compressionHandler(request, response);


### PR DESCRIPTION
This fixes a "blocked by CORS policy: Request header field 'range' is not allowed by Access-Control-Allow-Headers in preflight response." error in use cases where a cross-origin script makes a HTTP Range request.

The specific use case is running an [OpenLayers](https://github.com/openlayers/openlayers/) dev webserver (which is a [webpack-dev-server](https://github.com/webpack/webpack-dev-server), unable to handle files larger than 2GiB) with [geotiffjs](https://github.com/geotiffjs/geotiff.js) functionality (which makes the HTTP Range requests) side-by-side with `serve` to handle such file.

The specific error message in such a case would be `Access to fetch at 'http://localhost:5001/something.tif' from origin 'http://localhost:8080' has been blocked by CORS policy: Request header field range is not allowed by Access-Control-Allow-Headers in preflight response.` in Chromium, and  `Cross-origin request blocked: Same Origin Policy does not allow reading remote resources at http://localhost:5001/something.tif. (`[`Reason: missing token ‘range’ in CORS header ‘Access-Control-Allow-Headers’ from CORS preflight channel`](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors/CORSMissingAllowHeaderFromPreflight)`)` in Firefox.

