### PR TITLE
Fix spacing for CORS documentation

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -83,7 +83,7 @@ const getHelp = () => chalk`
 
       -c, --config                        Specify custom path to \`serve.json\`
 
-      -C, --cors						  Enable CORS, sets \`Access-Control-Allow-Origin\` to \`*\`
+      -C, --cors                          Enable CORS, sets \`Access-Control-Allow-Origin\` to \`*\`
 
       -n, --no-clipboard                  Do not copy the local address to the clipboard
 


### PR DESCRIPTION
Turns out that #599 had, in fact, misaligned spaces/tabs. This replaces tabs with spaces for consistency.