### PR TITLE
add --sab to enable SharedArrayBuffer

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -87,6 +87,9 @@ const getHelp = () => chalk`
 
       -C, --cors                          Enable CORS, sets \`Access-Control-Allow-Origin\` to \`*\`
 
+      --sab                               Enable SharedArrayBuffer, sets \`Cross-Origin-Opener-Policy\` to
+                                          \`same-origin\` and \`Cross-Origin-Embedder-Policy\` to \`require-corp\`
+
       -n, --no-clipboard                  Do not copy the local address to the clipboard
 
       -u, --no-compression                Do not compress files
@@ -192,6 +195,10 @@ const startEndpoint = (endpoint, config, args, previous) => {
 	const serverHandler = async (request, response) => {
 		if (args['--cors']) {
 			response.setHeader('Access-Control-Allow-Origin', '*');
+		}
+		if (args['--sab']) {
+			response.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+			response.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
 		}
 		if (compress) {
 			await compressionHandler(request, response);
@@ -376,6 +383,7 @@ const loadConfig = async (cwd, entry, args) => {
 			'--no-etag': Boolean,
 			'--symlinks': Boolean,
 			'--cors': Boolean,
+			'--sab': Boolean,
 			'--no-port-switching': Boolean,
 			'--ssl-cert': String,
 			'--ssl-key': String,


### PR DESCRIPTION
This is a super-specific change that I'm not sure makes a lot of sense being merged into serve. Basically, there's now an `--sab` flag to enable [two headers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#security_requirements) required to support `SharedArrayBuffer` instances in Firefox (Chrome seems to support the feature without the headers).

```sh
$ serve . --sab
```

The approach isn't necessarily the most ideal as I can imagine other headers being needed to support other web technologies. I personally want this flag so that readers of my upcoming book can spin up a local server with a one-liner and experiment with `SharedArrayBuffer`.

Perhaps a more general-purpose solution that makes sense for serve is to accept a list of headers provided via flags to be returned with each request, like so:

```sh
$ serve . --header Cross-Origin-Opener-Policy=same-origin --header Cross-Origin-Embedder-Policy=require-corp
```