### PR TITLE
HTTPS: Adding Ability to Send Passphrase to createServer

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -94,10 +94,14 @@ const getHelp = () => chalk`
       --no-etag                           Send \`Last-Modified\` header instead of \`ETag\`
 
       -S, --symlinks                      Resolve symlinks instead of showing 404 errors
+	  
+	  --ssl-cert                          Optional path to an SSL/TLS certificate to serve with HTTPS
+	  
+	  --ssl-key                           Optional path to the SSL/TLS certificate\'s private key
 
-      --ssl-cert                          Optional path to an SSL/TLS certificate to serve with HTTPS
+	  --ssl-ca                            Optional path to the SSL/TLS certificate\'s certificate authority
 
-      --ssl-key                           Optional path to the SSL/TLS certificate\'s private key
+	  --ssl-pass                          Optional path to the SSL/TLS certificate\'s passphrase
 
       --no-port-switching                 Do not open a port other than the one specified when it\'s taken.
 
@@ -203,7 +207,9 @@ const startEndpoint = (endpoint, config, args, previous) => {
 	const server = httpMode === 'https'
 		? https.createServer({
 			key: fs.readFileSync(args['--ssl-key']),
-			cert: fs.readFileSync(args['--ssl-cert'])
+			cert: fs.readFileSync(args['--ssl-cert']),
+			ca: fs.readFileSync(args['--ssl-ca']),
+			passphrase: fs.readFileSync(args['--ssl-pass'])
 		}, serverHandler)
 		: http.createServer(serverHandler);
 

--- a/bin/serve.js
+++ b/bin/serve.js
@@ -99,8 +99,6 @@ const getHelp = () => chalk`
 	  
 	  --ssl-key                           Optional path to the SSL/TLS certificate\'s private key
 
-	  --ssl-ca                            Optional path to the SSL/TLS certificate\'s certificate authority
-
 	  --ssl-pass                          Optional path to the SSL/TLS certificate\'s passphrase
 
       --no-port-switching                 Do not open a port other than the one specified when it\'s taken.
@@ -204,12 +202,13 @@ const startEndpoint = (endpoint, config, args, previous) => {
 		return handler(request, response, config);
 	};
 
+	const sslPass = args['--ssl-pass'];
+
 	const server = httpMode === 'https'
 		? https.createServer({
 			key: fs.readFileSync(args['--ssl-key']),
 			cert: fs.readFileSync(args['--ssl-cert']),
-			ca: fs.readFileSync(args['--ssl-ca']),
-			passphrase: fs.readFileSync(args['--ssl-pass'])
+			passphrase: sslPass ? fs.readFileSync(sslPass) : ''
 		}, serverHandler)
 		: http.createServer(serverHandler);
 
@@ -385,6 +384,7 @@ const loadConfig = async (cwd, entry, args) => {
 			'--no-port-switching': Boolean,
 			'--ssl-cert': String,
 			'--ssl-key': String,
+			'--ssl-pass': String,
 			'-h': '--help',
 			'-v': '--version',
 			'-l': '--listen',


### PR DESCRIPTION
**Purpose**
Adds ability to pass though an optional `passphrase` option for the ssl cert via a `--ssl-pass` param to `https.createServer`.

```js
https.createServer({
   key: fs.readFileSync(args['--ssl-key']),
   cert: fs.readFileSync(args['--ssl-cert']),
   passphrase: sslPass ? fs.readFileSync(sslPass) : ''
}
```