### PR TITLE
Fix network not being shown anymore

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -236,7 +236,7 @@ const startEndpoint = (endpoint, config, args, previous) => {
 			const ip = getNetworkAddress();
 
 			localAddress = `${httpMode}://${address}:${details.port}`;
-			networkAddress = networkAddress ? `${httpMode}://${ip}:${details.port}` : null;
+			networkAddress = ip ? `${httpMode}://${ip}:${details.port}` : null;
 		}
 
 		if (isTTY && process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
Close #658

I am astonished that a PR like #572 made it into production.

`networkAddress` is always null, for this reason the network address is not being shown anymore on any machine. I believe `ip` is what the author of that PR meant.