### PR TITLE
Add implicit support for PFX or PKCS12 encoded certificates

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -202,10 +202,12 @@ const startEndpoint = (endpoint, config, args, previous) => {
 	};
 
 	let sslPass = args['--ssl-pass'];
-	try {
-		sslPass = fs.readFileSync(sslPass, 'utf8').trim();
-	} catch (err) {
-		console.log('keeping plain value in ssl-pass');
+	if (sslPass) {
+		try {
+			sslPass = fs.readFileSync(sslPass, 'utf8').trim();
+		} catch (err) {
+			console.log('keeping plain value in ssl-pass');
+		}
 	}
 
 	const certPath = args['--ssl-cert'];


### PR DESCRIPTION
Similar to the PR #580 I followed this comment https://github.com/vercel/serve/pull/580#issuecomment-910615036 of @dakotaJang and added the PFX support without further program arguments.

The different certificate types are recognized from their file suffices.

Also, in this version the passphrases can be supplied either from file or directly from the string. This is distinguished by the existence of a file with the given name in parameter --ssl-pass.

Here some usage examples:
```
# start https with PEM certificate and decrypted keyfile
serve -l 8080 --ssl-cert mycert.crt --ssl-key mycert.decrypted.key

# start https with PEM certificate and encrypted keyfile with passphrase in file
# the file mycert.passphrase.txt contains a single line with the passphrase
serve -l 8080 --ssl-cert mycert.crt --ssl-key mycert.encrypted.key --ssl-pass mycert.passphrase.txt

# start https with PEM certificate and encrypted keyfile with passphrase from command argument
serve -l 8080 --ssl-cert mycert.crt --ssl-key mycert.encrypted.key --ssl-pass mysecretpa$$phrase

# start https with PKCS12 certificate and passphrase in file
serve -l 8080 --ssl-cert mycert.pfx --ssl-pass mycert.passphrase.txt

# start https with PKCS12 certificate and passphrase from command argument
serve -l 8080 --ssl-cert mycert.pfx --ssl-pass mysecretpa$$phrase
```

The relevant section of the new --help info is
```
      --ssl-cert                          Optional path to an SSL/TLS certificate in PEM or PKCS #12 format
                                          to serve with HTTPS
      --ssl-key                           Optional path to the PEM certificate's private key

      --ssl-pass                          Optional path to the PEM or PKCS #12 certificate's passphrase
                                          or password for PEM or PKCS #12 crypto file
```
