### PR TITLE
Change default port from `5000` to `3000`

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -63,7 +63,7 @@ const getHelp = () => chalk`
       {bold $} {cyan serve} folder_name
       {bold $} {cyan serve} [-l {underline listen_uri} [-l ...]] [{underline directory}]
 
-      By default, {cyan serve} will listen on {bold 0.0.0.0:5000} and serve the
+      By default, {cyan serve} will listen on {bold 0.0.0.0:3000} and serve the
       current working directory on that address.
 
       Specifying a single {bold --listen} argument will overwrite the default, not supplement it.
@@ -152,7 +152,7 @@ const parseEndpoint = (str) => {
 
 		return [url.pathname];
 	case 'tcp:':
-		url.port = url.port || '5000';
+		url.port = url.port || '3000';
 		return [parseInt(url.port, 10), url.hostname];
 	default:
 		throw new Error(`Unknown --listen endpoint scheme (protocol): ${url.protocol}`);
@@ -419,7 +419,7 @@ const loadConfig = async (cwd, entry, args) => {
 
 	if (!args['--listen']) {
 		// Default endpoint
-		args['--listen'] = [[process.env.PORT || 5000]];
+		args['--listen'] = [[process.env.PORT || 3000]];
 	}
 
 	if (args._.length > 1) {


### PR DESCRIPTION
Due to a conflict with AirPlay, it could be interesting to change the default port: https://developer.apple.com/forums/thread/682332

related: https://github.com/vercel/serve/issues/672
info: https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers