### PR TITLE
fix: read passphrase from file as string

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -208,7 +208,7 @@ const startEndpoint = (endpoint, config, args, previous) => {
 		? https.createServer({
 			key: fs.readFileSync(args['--ssl-key']),
 			cert: fs.readFileSync(args['--ssl-cert']),
-			passphrase: sslPass ? fs.readFileSync(sslPass) : ''
+			passphrase: sslPass ? fs.readFileSync(sslPass, "utf8") : ''
 		}, serverHandler)
 		: http.createServer(serverHandler);
 


### PR DESCRIPTION
Environment: Windows 11
Node: v16.13.0

# Issue
There is an issue when trying to serve HTTPS server, the --ssl-pass should pass as an argument, the readFileSync function returns an instance of Buffer and raise an exception with the following message:
```
node:internal/errors:464
    ErrorCaptureStackTrace(err);
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "options.passphrase" property must be of type string. Received an instance of Buffer
    at new NodeError (node:internal/errors:371:5)
    at validateString (node:internal/validators:119:11)
    at setKey (node:internal/tls/secure-context:87:5)
    at configSecureContext (node:internal/tls/secure-context:168:7)
    at Object.createSecureContext (node:_tls_common:116:3)
    at Server.setSecureContext (node:_tls_wrap:1344:27)
    at Server (node:_tls_wrap:1203:8)
    at new Server (node:https:69:3)
    at Object.createServer (node:https:105:10)
    at startEndpoint (C:\Users\ARB\AppData\Roaming\npm\node_modules\serve\bin\serve.js:208:11) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```

# Solution
add utf8 as second parameter of  readFileSync function