### PR TITLE
Fix not showing network address on Node 18

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -178,7 +178,7 @@ const getNetworkAddress = () => {
 	for (const name of Object.keys(interfaces)) {
 		for (const interface of interfaces[name]) {
 			const {address, family, internal} = interface;
-			if (family === 'IPv4' && !internal) {
+			if (['IPv4', 4].includes(family) && !internal) {
 				return address;
 			}
 		}


### PR DESCRIPTION
Since Node 18, `family` is a number 👉 https://nodejs.org/api/os.html#os_os_networkinterfaces