### PR TITLE
fix(utilities/cli): use `chalk-template` to render help message

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "arg": "5.0.2",
     "boxen": "7.0.0",
     "chalk": "5.0.1",
+    "chalk-template": "0.4.0",
     "clipboardy": "3.0.0",
     "compression": "1.7.4",
     "is-port-reachable": "4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ specifiers:
   arg: 5.0.2
   boxen: 7.0.0
   chalk: 5.0.1
+  chalk-template: 0.4.0
   clipboardy: 3.0.0
   compression: 1.7.4
   eslint: 8.19.0
@@ -28,6 +29,7 @@ dependencies:
   arg: 5.0.2
   boxen: 7.0.0
   chalk: 5.0.1
+  chalk-template: 0.4.0
   clipboardy: 3.0.0
   compression: 1.7.4
   is-port-reachable: 4.0.0
@@ -754,7 +756,6 @@ packages:
     engines: { node: '>=8' }
     dependencies:
       color-convert: 2.0.1
-    dev: true
 
   /ansi-styles/6.1.0:
     resolution:
@@ -1008,6 +1009,16 @@ packages:
     engines: { node: '>=14.16' }
     dev: false
 
+  /chalk-template/0.4.0:
+    resolution:
+      {
+        integrity: sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==,
+      }
+    engines: { node: '>=12' }
+    dependencies:
+      chalk: 4.1.2
+    dev: false
+
   /chalk/2.4.1:
     resolution:
       {
@@ -1029,7 +1040,6 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
-    dev: true
 
   /chalk/5.0.1:
     resolution:
@@ -1151,7 +1161,6 @@ packages:
     engines: { node: '>=7.0.0' }
     dependencies:
       color-name: 1.1.4
-    dev: true
 
   /color-name/1.1.3:
     resolution:
@@ -1165,7 +1174,6 @@ packages:
       {
         integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
       }
-    dev: true
 
   /colorette/2.0.19:
     resolution:
@@ -2486,7 +2494,6 @@ packages:
         integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==,
       }
     engines: { node: '>=8' }
-    dev: true
 
   /has-property-descriptors/1.0.0:
     resolution:
@@ -4306,7 +4313,6 @@ packages:
     engines: { node: '>=8' }
     dependencies:
       has-flag: 4.0.0
-    dev: true
 
   /supports-preserve-symlinks-flag/1.0.0:
     resolution:

--- a/source/main.ts
+++ b/source/main.ts
@@ -28,7 +28,7 @@ const printUpdateNotification = async (debugMode?: boolean) => {
   const [error, update] = await resolve(checkForUpdate(manifest));
 
   if (error) {
-    const suffix = debugMode ? ':' : ' (use `--debug` to see full error)';
+    const suffix = debugMode ? ':' : ' (use `--debug` to see full error).';
     logger.warn(`Checking for updates failed${suffix}`);
 
     if (debugMode) logger.error(error.message);
@@ -36,7 +36,8 @@ const printUpdateNotification = async (debugMode?: boolean) => {
   if (!update) return;
 
   logger.log(
-    chalk` {bgRed.white  UPDATE } The latest version of \`serve\` is ${update.latest}`,
+    chalk.bgRed.white(' UPDATE '),
+    `The latest version of \`serve\` is ${update.latest}.`,
   );
 };
 
@@ -115,7 +116,7 @@ for (const endpoint of args['--listen']) {
   // If we are not in a TTY or Node is running in production mode, print
   // a single line of text with the server address.
   if (!process.stdout.isTTY || process.env.NODE_ENV === 'production') {
-    const suffix = local ? ` at ${local}` : '';
+    const suffix = local ? ` at ${local}.` : '.';
     logger.info(`Accepting connections${suffix}`);
 
     continue;
@@ -144,7 +145,9 @@ for (const endpoint of args['--listen']) {
       await clipboard.write(local);
       message += `\n\n${chalk.grey('Copied local address to clipboard!')}`;
     } catch (error: unknown) {
-      logger.error(`Cannot copy to clipboard: ${(error as Error).message}`);
+      logger.error(
+        `Cannot copy server address to clipboard: ${(error as Error).message}.`,
+      );
     }
   }
 

--- a/source/utilities/cli.ts
+++ b/source/utilities/cli.ts
@@ -1,7 +1,7 @@
 // source/utilities/cli.ts
 // CLI-related utility functions.
 
-import chalk from 'chalk';
+import chalk from 'chalk-template';
 import parseArgv from 'arg';
 import { parseEndpoint } from './http.js';
 import type { Arguments } from '../types.js';


### PR DESCRIPTION
## Related Issues

Closes #711.

## Description

- adds `chalk-template` as a dependency
- uses `chalk-template` for rendering the help message in `source/utilities/cli.ts`