### PR TITLE
Add no-cache flag

### DIFF
--- a/source/utilities/cli.ts
+++ b/source/utilities/cli.ts
@@ -66,6 +66,8 @@ const helpText = chalkTemplate`
 
     --no-port-switching                 Do not open a port other than the one specified when it\'s taken.
 
+    --no-cache                          Sets \`Cache-Control\` to \`no-cache, no-store, must-revalidate\`
+
   {bold ENDPOINTS}
 
     Listen endpoints (specified by the {bold --listen} or {bold -l} options above) instruct {cyan serve}

--- a/source/utilities/server.ts
+++ b/source/utilities/server.ts
@@ -63,6 +63,8 @@ export const startServer = async (
 
       if (args['--cors'])
         response.setHeader('Access-Control-Allow-Origin', '*');
+      if (args['--no-cache'])
+        response.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
       if (!args['--no-compression'])
         await compress(request as ExpressRequest, response as ExpressResponse);
 


### PR DESCRIPTION
The PR allows us to disable browser cache. It can be suitable if we often change served content.