### PR TITLE
Bump `serve-handler` from `6.1.3` to `6.1.5`

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "clipboardy": "3.0.0",
     "compression": "1.7.4",
     "is-port-reachable": "4.0.0",
-    "serve-handler": "6.1.4",
+    "serve-handler": "6.1.5",
     "update-check": "1.5.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "clipboardy": "3.0.0",
     "compression": "1.7.4",
     "is-port-reachable": "4.0.0",
-    "serve-handler": "6.1.3",
+    "serve-handler": "6.1.4",
     "update-check": "1.5.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ specifiers:
   is-port-reachable: 4.0.0
   lint-staged: 13.0.3
   prettier: 2.7.1
-  serve-handler: 6.1.4
+  serve-handler: 6.1.5
   tsup: 6.1.3
   tsx: 3.7.1
   typescript: 4.6.4
@@ -37,7 +37,7 @@ dependencies:
   clipboardy: 3.0.0
   compression: 1.7.4
   is-port-reachable: 4.0.0
-  serve-handler: 6.1.4
+  serve-handler: 6.1.5
   update-check: 1.5.4
 
 devDependencies:
@@ -1103,7 +1103,10 @@ packages:
     dev: true
 
   /bytes/3.0.0:
-    resolution: { integrity: sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg= }
+    resolution:
+      {
+        integrity: sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==,
+      }
     engines: { node: '>= 0.8' }
     dev: false
 
@@ -4580,10 +4583,10 @@ packages:
       lru-cache: 6.0.0
     dev: true
 
-  /serve-handler/6.1.4:
+  /serve-handler/6.1.5:
     resolution:
       {
-        integrity: sha512-eUeq/TKgqDUkr8/3jAIbX32DF27G6+s3tCWnXwD2gDK97FISLn4opPsfRp6bNtgVeLjWosjMojAfna6VqActAg==,
+        integrity: sha512-ijPFle6Hwe8zfmBxJdE+5fta53fdIY0lHISJvuikXB3VYFafRjMRpOffSPvCYsbKyBA7pvy9oYr/BT1O3EArlg==,
       }
     dependencies:
       bytes: 3.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ specifiers:
   is-port-reachable: 4.0.0
   lint-staged: 13.0.3
   prettier: 2.7.1
-  serve-handler: 6.1.3
+  serve-handler: 6.1.4
   tsup: 6.1.3
   tsx: 3.7.1
   typescript: 4.6.4
@@ -37,7 +37,7 @@ dependencies:
   clipboardy: 3.0.0
   compression: 1.7.4
   is-port-reachable: 4.0.0
-  serve-handler: 6.1.3
+  serve-handler: 6.1.4
   update-check: 1.5.4
 
 devDependencies:
@@ -1457,10 +1457,16 @@ packages:
     dev: false
 
   /concat-map/0.0.1:
-    resolution: { integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s= }
+    resolution:
+      {
+        integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==,
+      }
 
   /content-disposition/0.5.2:
-    resolution: { integrity: sha1-DPaLud318r55YcOoUXjLhdunjLQ= }
+    resolution:
+      {
+        integrity: sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==,
+      }
     engines: { node: '>= 0.6' }
     dev: false
 
@@ -3689,15 +3695,6 @@ packages:
     engines: { node: '>=4' }
     dev: true
 
-  /minimatch/3.0.4:
-    resolution:
-      {
-        integrity: sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==,
-      }
-    dependencies:
-      brace-expansion: 1.1.11
-    dev: false
-
   /minimatch/3.1.2:
     resolution:
       {
@@ -4084,7 +4081,10 @@ packages:
     engines: { node: '>=0.10.0' }
 
   /path-is-inside/1.0.2:
-    resolution: { integrity: sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM= }
+    resolution:
+      {
+        integrity: sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==,
+      }
     dev: false
 
   /path-key/3.1.1:
@@ -4580,17 +4580,17 @@ packages:
       lru-cache: 6.0.0
     dev: true
 
-  /serve-handler/6.1.3:
+  /serve-handler/6.1.4:
     resolution:
       {
-        integrity: sha512-FosMqFBNrLyeiIDvP1zgO6YoTzFYHxLDEIavhlmQ+knB2Z7l1t+kGLHkZIDN7UVWqQAmKI3D20A6F6jo3nDd4w==,
+        integrity: sha512-eUeq/TKgqDUkr8/3jAIbX32DF27G6+s3tCWnXwD2gDK97FISLn4opPsfRp6bNtgVeLjWosjMojAfna6VqActAg==,
       }
     dependencies:
       bytes: 3.0.0
       content-disposition: 0.5.2
       fast-url-parser: 1.1.3
       mime-types: 2.1.18
-      minimatch: 3.0.4
+      minimatch: 3.1.2
       path-is-inside: 1.0.2
       path-to-regexp: 2.2.1
       range-parser: 1.2.0


### PR DESCRIPTION
Bumps `serve-handler` to version 6.1.5 which includes a security fix for `minimatch`.

See https://github.com/vercel/serve-handler/issues/179