### PR TITLE
Add publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,7 +24,7 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install
-      - name: Run all tests
+      - name: Compile
         run: pnpm compile
       - name: Run all tests
         run: pnpm test

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,34 @@
+name: Publish Package
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+      - name: Setup PNPM 7
+        uses: pnpm/action-setup@v2.0.1
+        with:
+          version: latest
+      - name: Setup Node 18
+        uses: actions/setup-node@v2
+        with:
+          node-version: 18
+          registry-url: 'https://registry.npmjs.org/'
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+      - name: Run all tests
+        run: pnpm compile
+      - name: Run all tests
+        run: pnpm test
+      - name: Publish
+        run: pnpm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}


### PR DESCRIPTION
Adds a `publish` workflow that will allow us to publish a new version more easily.

We might eventually switch to something more automated like [Changesets](https://github.com/changesets/changesets), however, for simplicity I've used the same approach as in `serve-handler`.

In order to publish a new version, one would need to bump the version in package.json, add a Git tag, and then create a release on GitHub.

Running `release [major|minor|patch]` would take care of most of that.