### PR TITLE
Update CORS headers to support PNA spec

### DIFF
--- a/source/utilities/server.ts
+++ b/source/utilities/server.ts
@@ -61,8 +61,11 @@ export const startServer = async (
           chalk.cyan(requestUrl),
         );
 
-      if (args['--cors'])
+      if (args['--cors']) {
         response.setHeader('Access-Control-Allow-Origin', '*');
+        response.setHeader('Access-Control-Allow-Credentials', 'true');
+        response.setHeader('Access-Control-Allow-Private-Network', 'true');
+      }
       if (!args['--no-compression'])
         await compress(request as ExpressRequest, response as ExpressResponse);
 


### PR DESCRIPTION
Serve is currently broken in Microsoft Edge (strict mode), since Edge is trialling the rollout of the [Private Network Access (PNA)](https://developer.chrome.com/blog/private-network-access-preflight/) spec. Chrome is planning on rolling this out soon, so it's only a matter of time before this affects more users. 

These new headers allow non-localhost websites to make fetch requests to http://localhost