### PR TITLE
type:docs Show how to fall back on index.html (single-page applications)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,11 @@ Once that's done, you can run this command inside your project's directory...
 > serve folder-name/
 ```
 
+You can make all unknown paths fall back on `index.html` (which should often be the case in single-page applications):
+```bash
+> serve --single
+```
+
 Finally, run this command to see a list of all available options:
 
 ```bash


### PR DESCRIPTION
Single-page applications often rely on client-side routing and should serve `index.html` as a default page for all unknown paths (that is, any path that does not match one of the files served).

This can be achieved with option `--single` (see `serve --help`).
However, this important option is hardly visible as it does not belong to [serve-handler](https://github.com/vercel/serve-handler#options) options that are linked to in `readme.md`.