### PR TITLE
Lock PNPM version to 7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup PNPM 7
         uses: pnpm/action-setup@v2.0.1
         with:
-          version: latest
+          version: 7
       - name: Setup Node 18
         uses: actions/setup-node@v2
         with:
@@ -34,7 +34,7 @@ jobs:
       - name: Setup PNPM 7
         uses: pnpm/action-setup@v2.0.1
         with:
-          version: latest
+          version: 7
       - name: Setup Node 18
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup PNPM 7
         uses: pnpm/action-setup@v2.0.1
         with:
-          version: latest
+          version: 7
       - name: Setup Node 18
         uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
CI and publishing fails because the lockfile was generated with PNPM 7, while GitHub Actions installs PNPM 8.