### PR TITLE
fix: Update `ajv` from 8.11.0 to 8.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@zeit/schemas": "2.29.0",
-    "ajv": "8.11.0",
+    "ajv": "8.12.0",
     "arg": "5.0.2",
     "boxen": "7.0.0",
     "chalk": "5.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ specifiers:
   '@types/serve-handler': 6.1.1
   '@vercel/style-guide': 3.0.0
   '@zeit/schemas': 2.29.0
-  ajv: 8.11.0
+  ajv: 8.12.0
   arg: 5.0.2
   boxen: 7.0.0
   c8: 7.12.0
@@ -28,7 +28,7 @@ specifiers:
 
 dependencies:
   '@zeit/schemas': 2.29.0
-  ajv: 8.11.0
+  ajv: 8.12.0
   arg: 5.0.2
   boxen: 7.0.0
   chalk: 5.0.1
@@ -824,10 +824,10 @@ packages:
       uri-js: 4.4.1
     dev: true
 
-  /ajv/8.11.0:
+  /ajv/8.12.0:
     resolution:
       {
-        integrity: sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==,
+        integrity: sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==,
       }
     dependencies:
       fast-deep-equal: 3.1.3


### PR DESCRIPTION
Updates pinned dependency `ajv` to latest.

#### [Release Notes 8.12.0](https://github.com/ajv-validator/ajv/releases/tag/v8.12.0):

> - fix JTD serialisation (remove leading comma in objects with only optional properties) (https://github.com/ajv-validator/ajv/pull/2190, @piliugin-anton)
> - empty JTD "values" schema (https://github.com/ajv-validator/ajv/pull/2191)
> - empty object to work with JTD utility type (https://github.com/ajv-validator/ajv/pull/2158, @erikbrinkman)
> - fix JTD "discriminator" schema for objects with more than 8 properties (https://github.com/ajv-validator/ajv/pull/2194)
> - correctly narrow "number" type to "integer" (https://github.com/ajv-validator/ajv/pull/2192, @JacobLey)

#### [Release Notes 8.11.2](https://github.com/ajv-validator/ajv/releases/tag/v8.11.2):
> - Update dependencies
> - Export ValidationError and MissingRefError (https://github.com/ajv-validator/ajv/pull/1840, @dannyb648)

#### [8.11.1 was pre-release of 8.11.2](https://github.com/ajv-validator/ajv/releases/tag/v8.11.1)

#### Diffs

[Source diff `v8.12.0...v8.11.0`](https://github.com/ajv-validator/ajv/compare/v8.11.0...v8.12.0)

[Package diff `ajv@8.12.0...ajv@8.11.0`](https://npm-diff.app/ajv@8.12.0...ajv@8.11.0)