### PR TITLE
Bump `@zeit/schemas` to `2.36.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "prepare": "husky install config/husky && pnpm compile"
   },
   "dependencies": {
-    "@zeit/schemas": "2.29.0",
+    "@zeit/schemas": "2.36.0",
     "ajv": "8.12.0",
     "arg": "5.0.2",
     "boxen": "7.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ specifiers:
   '@types/compression': 1.7.2
   '@types/serve-handler': 6.1.1
   '@vercel/style-guide': 3.0.0
-  '@zeit/schemas': 2.29.0
+  '@zeit/schemas': 2.36.0
   ajv: 8.12.0
   arg: 5.0.2
   boxen: 7.0.0
@@ -27,7 +27,7 @@ specifiers:
   vitest: 0.18.0
 
 dependencies:
-  '@zeit/schemas': 2.29.0
+  '@zeit/schemas': 2.36.0
   ajv: 8.12.0
   arg: 5.0.2
   boxen: 7.0.0
@@ -763,10 +763,10 @@ packages:
       - typescript
     dev: true
 
-  /@zeit/schemas/2.29.0:
+  /@zeit/schemas/2.36.0:
     resolution:
       {
-        integrity: sha512-g5QiLIfbg3pLuYUJPlisNKY+epQJTcMDsOnVNkscrDP1oi7vmJnzOANYJI/1pZcVJ6umUkBv3aFtlg1UvUHGzA==,
+        integrity: sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg==,
       }
     dev: false
 


### PR DESCRIPTION
Resolves https://github.com/vercel/serve/issues/519

Includes the schema fix from https://github.com/vercel/schemas/pull/53
