### PR TITLE
X handle has changed

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -93,4 +93,4 @@ This project used to be called `list` and `micro-list`. But thanks to [TJ Holowa
 
 ## Author
 
-Leo Lamprecht ([@notquiteleo](https://twitter.com/notquiteleo))
+Leo Lamprecht ([@leo](https://x.com/leo))


### PR DESCRIPTION
Twitter was renamed to X and my X handle changed from `@notquiteleo` to `@leo`.

This change replaces the previous broken link with the new working link.