### PR TITLE
feat: `--[no]-trailing-slash` CLI flags

### DIFF
--- a/source/types.ts
+++ b/source/types.ts
@@ -79,6 +79,8 @@ export declare interface Options {
   '--no-clipboard': boolean;
   '--no-compression': boolean;
   '--no-etag': boolean;
+  '--trailing-slash': boolean;
+  '--no-trailing-slash': boolean;
   '--symlinks': boolean;
   '--cors': boolean;
   '--no-port-switching': boolean;

--- a/source/utilities/cli.ts
+++ b/source/utilities/cli.ts
@@ -54,6 +54,8 @@ const helpText = chalkTemplate`
 
     --no-etag                           Send \`Last-Modified\` header instead of \`ETag\`
 
+    --[no]-trailing-slash               Remove or add trailing slashes to all paths
+
     -S, --symlinks                      Resolve symlinks instead of showing 404 errors
     
     --ssl-cert                          Optional path to an SSL/TLS certificate to serve with HTTPS
@@ -153,6 +155,8 @@ const options = {
   '--no-clipboard': Boolean,
   '--no-compression': Boolean,
   '--no-etag': Boolean,
+  '--trailing-slash': Boolean,
+  '--no-trailing-slash': Boolean,
   '--symlinks': Boolean,
   '--cors': Boolean,
   '--no-port-switching': Boolean,

--- a/source/utilities/config.ts
+++ b/source/utilities/config.ts
@@ -139,6 +139,13 @@ export const loadConfiguration = async (
   // Configure defaults based on the options the user has passed.
   config.etag = !args['--no-etag'];
   config.symlinks = args['--symlinks'] || config.symlinks;
+  const trailingSlash = args['--trailing-slash'];
+  const noTrailingSlash = args['--no-trailing-slash'];
+  if (trailingSlash !== undefined) {
+    config.trailingSlash = trailingSlash;
+  } else if (noTrailingSlash !== undefined) {
+    config.trailingSlash = !noTrailingSlash;
+  }
 
   return config;
 };

--- a/tests/__fixtures__/config/custom/config.json
+++ b/tests/__fixtures__/config/custom/config.json
@@ -1,4 +1,5 @@
 {
   "public": "app/",
+  "trailingSlash": true,
   "renderSingle": true
 }

--- a/tests/__snapshots__/cli.test.ts.snap
+++ b/tests/__snapshots__/cli.test.ts.snap
@@ -43,6 +43,8 @@ exports[`utilities/cli > render help text 1`] = `
 
     --no-etag                           Send \`Last-Modified\` header instead of \`ETag\`
 
+    --[no]-trailing-slash               Remove or add trailing slashes to all paths
+
     -S, --symlinks                      Resolve symlinks instead of showing 404 errors
     
     --ssl-cert                          Optional path to an SSL/TLS certificate to serve with HTTPS

--- a/tests/__snapshots__/config.test.ts.snap
+++ b/tests/__snapshots__/config.test.ts.snap
@@ -15,6 +15,7 @@ exports[`utilities/config > parse valid config at custom location 1`] = `
   "public": "tests/__fixtures__/config/custom/app",
   "renderSingle": true,
   "symlinks": undefined,
+  "trailingSlash": true,
 }
 `;
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -52,6 +52,40 @@ describe('utilities/config', () => {
     expect(configuration).toMatchSnapshot();
   });
 
+  // The `--trailing-slash` flag should set `trailingSlash` to `true`.
+  test('sets `trailingSlash` to `true` when --trailing-slash flag is set', async () => {
+    const configuration = await loadConfiguration(
+      process.cwd(),
+      process.cwd(),
+      {
+        '--trailing-slash': true,
+      },
+    );
+    expect(configuration.trailingSlash).toBe(true);
+  });
+
+  // The `--no-trailing-slash` flag should set `trailingSlash` to `false`.
+  test('sets `trailingSlash` to `false` when --no-trailing-slash flag is set', async () => {
+    const configuration = await loadConfiguration(
+      process.cwd(),
+      process.cwd(),
+      {
+        '--no-trailing-slash': true,
+      },
+    );
+    expect(configuration.trailingSlash).toBe(false);
+  });
+
+  // When `--[no]-trailing-slash` is not specified, `trailingSlash` should be `undefined`.
+  test('sets `trailingSlash` to `undefined` when trailing slash flags are omitted', async () => {
+    const configuration = await loadConfiguration(
+      process.cwd(),
+      process.cwd(),
+      {},
+    );
+    expect(configuration.trailingSlash).toBeUndefined();
+  });
+
   // When the configuration source is deprecated, i.e., the configuration lives
   // in `now.json` or `package.json`, a warning should be printed.
   test('warn when configuration comes from a deprecated source', async () => {


### PR DESCRIPTION
## Changes
* Add `--trailing-slash` and `--no-trailing-slash` CLI flags, which correlate to `"trailingSlash": true` and `"trailingSlash": false` in `serve.json`.
* Update affected tests.
* Add tests for new CLI flags.

## Rationale
I ran into #628 while using `serve` to view Jest coverage reports. I was able to bypass the issue using `serve.json`, but I needed to put it outside the `coverage/` directory (which is in `.gitignore`) and use the `-c` flag to link it. Felt like overkill for a pretty simple flag, so I added it to the CLI!