### PR TITLE
Add missing setup step for Changeset

### DIFF
--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -22,6 +22,10 @@ jobs:
           node-version: 22
           registry-url: 'https://registry.npmjs.org/'
           cache: 'pnpm'
+      - name: Add npm auth token to pnpm
+        run: pnpm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN_ELEVATED}"
+        env:
+          NPM_TOKEN_ELEVATED: ${{secrets.NPM_TOKEN_ELEVATED}}
       - name: Install dependencies
         run: pnpm install
       - name: Add SHORT_SHA env property with commit short sha

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,10 @@ jobs:
           node-version: 22
           registry-url: 'https://registry.npmjs.org/'
           cache: 'pnpm'
+      - name: Add npm auth token to pnpm
+        run: pnpm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN_ELEVATED}"
+        env:
+          NPM_TOKEN_ELEVATED: ${{secrets.NPM_TOKEN_ELEVATED}}
       - name: Install dependencies
         run: pnpm install
       - name: Compile


### PR DESCRIPTION
Ensures we call `pnpm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN_ELEVATED}"` in the setup before publishing.